### PR TITLE
Update hdinsight-service-endpoint-policy-resources.json

### DIFF
--- a/hdinsight-service-endpoint-policy-resources.json
+++ b/hdinsight-service-endpoint-policy-resources.json
@@ -271,7 +271,8 @@
         "/subscriptions/8360c904-55c1-45c7-b877-225ae2a11876/resourceGroups/weustorage",
         "/subscriptions/6a853a41-3423-4167-8d9c-bcf37dc72818/resourceGroups/GenevaWarmPathManageRG",
         "/subscriptions/da0c4c68-9283-4f88-9c35-18f7bd72fbdd/resourceGroups/GenevaWarmPathManageRG",
-        "/subscriptions/235d341f-7fb9-435c-9bdc-034b7306c9b4/resourceGroups/Default-Storage-WestUS"
+        "/subscriptions/235d341f-7fb9-435c-9bdc-034b7306c9b4/resourceGroups/Default-Storage-WestUS",
+        "/subscriptions/8360c904-55c1-45c7-b877-225ae2a11876/resourceGroups/westeustorage"
     ],
     "France Central":[
         "/subscriptions/235d341f-7fb9-435c-9bdc-034b7306c9b4/resourceGroups/Default-Storage-WestUS",


### PR DESCRIPTION
West Europe has extra storage accounts in the mentioned resource group. Added it to policy

## Purpose
For HDInsight product some of storage accounts are provisioned in different resource group. To allow customers to access these storage accounts we added that resource group to policy list
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Manually tested
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->